### PR TITLE
Drop lunar builds, use ros-testing repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Travis Continuous Integration Configuration File For ROS Control Projects
-language: generic # optional, just removes the language badge
-
+language: generic
 services:
   - docker
 
@@ -14,19 +13,14 @@ notifications:
     on_failure: change #[always|never|change] # default: always
 
 env:
-  global:
-    - UPSTREAM_WORKSPACE=https://raw.github.com/ros-controls/ros_control/\${ROS_DISTRO/lunar/kinetic}-devel/ros_control.rosinstall -control_msgs
   matrix:
-    - ROS_DISTRO=kinetic ROS_REPO=ros
-    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed
-    - ROS_DISTRO=lunar   ROS_REPO=ros
-    - ROS_DISTRO=lunar   ROS_REPO=ros-shadow-fixed
-    - ROS_DISTRO=melodic ROS_REPO=ros
-    - ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed
-    - ROS_DISTRO=melodic ROS_REPO=ros BUILDER=colcon
+    - ROS_DISTRO=kinetic ROS_REPO=ros                UPSTREAM_WORKSPACE='https://raw.github.com/ros-controls/ros_control/\kinetic-devel/ros_control.rosinstall -control_msgs'
+    - ROS_DISTRO=kinetic ROS_REPO=ros-testing        UPSTREAM_WORKSPACE='https://raw.github.com/ros-controls/ros_control/\kinetic-devel/ros_control.rosinstall -control_msgs'
+    - ROS_DISTRO=melodic ROS_REPO=ros                UPSTREAM_WORKSPACE='https://raw.github.com/ros-controls/ros_control/\melodic-devel/ros_control.rosinstall -control_msgs'
+    - ROS_DISTRO=melodic ROS_REPO=ros-testing        UPSTREAM_WORKSPACE='https://raw.github.com/ros-controls/ros_control/\melodic-devel/ros_control.rosinstall -control_msgs'
+    - ROS_DISTRO=melodic ROS_REPO=ros BUILDER=colcon UPSTREAM_WORKSPACE='https://raw.github.com/ros-controls/ros_control/\melodic-devel/ros_control.rosinstall -control_msgs'
 
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
-
 script:
 - .industrial_ci/travis.sh


### PR DESCRIPTION
 - Removes Lunar builds, since Lunar is EOL
 - Switches from `ros-shadow-fixed` to `ros-testing`
 - Fixes `UPSTREAM_WORKSPACE`