### PR TITLE
Add JointJog.msg to Foxy

### DIFF
--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -28,6 +28,7 @@ set(msg_files
   msg/GripperCommand.msg
   msg/InterfaceValue.msg
   msg/JointControllerState.msg
+  msg/JointJog.msg
   msg/JointTolerance.msg
   msg/JointTrajectoryControllerState.msg
   msg/PidState.msg

--- a/control_msgs/msg/JointJog.msg
+++ b/control_msgs/msg/JointJog.msg
@@ -1,0 +1,20 @@
+# Used in time-stamping the message.
+Header header
+
+# Name list of the joints. You don't need to specify all joints of the
+# robot. Joint names are case-sensitive.
+string[] joint_names
+
+# A position command to the joints listed in joint_names.
+# The order must be identical.
+# Units are meters or radians.
+# If displacements and velocities are filled, a profiled motion is requested.
+float64[] displacements # or position_deltas
+
+# A velocity command to the joints listed in joint_names.
+# The order must be identical.
+# Units are m/s or rad/s.
+# If displacements and velocities are filled, a profiled motion is requested.
+float64[] velocities
+
+float64 duration

--- a/control_msgs/msg/JointJog.msg
+++ b/control_msgs/msg/JointJog.msg
@@ -1,5 +1,5 @@
 # Used in time-stamping the message.
-Header header
+std_msgs/Header header
 
 # Name list of the joints. You don't need to specify all joints of the
 # robot. Joint names are case-sensitive.


### PR DESCRIPTION
I am working to port part of MoveIt to ROS2, and we depend on `control_msgs/msg/JointJog.msg` (see [https://github.com/ros-planning/moveit2/issues/206](https://github.com/ros-planning/moveit2/issues/206))

This PR just copies the commit that added this message to the default branch with minor fixes for ROS2. 