### PR TITLE
Extend QueryTrajectoryState to allow to report errors

### DIFF
--- a/control_msgs/srv/QueryTrajectoryState.srv
+++ b/control_msgs/srv/QueryTrajectoryState.srv
@@ -1,5 +1,8 @@
 builtin_interfaces/Time time
 ---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages
+
 string[] name
 float64[] position
 float64[] velocity


### PR DESCRIPTION
Afaik there's no way of reporting an error on a service call in ROS2 other than adding fields to the service response.

In order to port the `query_state` service to ROS2 I need to be able to report [some errors](https://github.com/ros-controls/ros_controllers/blob/melodic-devel/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h#L681)

If there's a different way of doing this, I'll be happy to change it.