### PR TITLE
Multi dof action extension

### DIFF
--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -26,6 +26,7 @@ set(msg_files
   msg/JointJog.msg
   msg/JointTolerance.msg
   msg/JointTrajectoryControllerState.msg
+  msg/MultiDOFJointTolerance.msg
   msg/PidState.msg
 )
 

--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -22,11 +22,11 @@ set(msg_files
   msg/DynamicJointState.msg
   msg/GripperCommand.msg
   msg/InterfaceValue.msg
+  msg/JointComponentTolerance.msg
   msg/JointControllerState.msg
   msg/JointJog.msg
   msg/JointTolerance.msg
   msg/JointTrajectoryControllerState.msg
-  msg/MultiDOFJointTolerance.msg
   msg/PidState.msg
 )
 

--- a/control_msgs/action/FollowJointTrajectory.action
+++ b/control_msgs/action/FollowJointTrajectory.action
@@ -1,5 +1,6 @@
-# The joint trajectory to follow
+# The trajectory for all revolute, continuous or prismatic joints
 trajectory_msgs/JointTrajectory trajectory
+# The trajectory for all planar or floating joints (i.e. individual joints with more than one DOF)
 trajectory_msgs/MultiDOFJointTrajectory multi_dof_trajectory
 
 # Tolerances for the trajectory.  If the measured joint values fall

--- a/control_msgs/action/FollowJointTrajectory.action
+++ b/control_msgs/action/FollowJointTrajectory.action
@@ -58,3 +58,4 @@ trajectory_msgs/JointTrajectoryPoint error
 string[] multi_dof_joint_names
 trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_desired
 trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_actual
+trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_error

--- a/control_msgs/action/FollowJointTrajectory.action
+++ b/control_msgs/action/FollowJointTrajectory.action
@@ -1,5 +1,6 @@
 # The joint trajectory to follow
 trajectory_msgs/JointTrajectory trajectory
+trajectory_msgs/MultiDOFJointTrajectory multi_dof_trajectory
 
 # Tolerances for the trajectory.  If the measured joint values fall
 # outside the tolerances the trajectory goal is aborted.  Any

--- a/control_msgs/action/FollowJointTrajectory.action
+++ b/control_msgs/action/FollowJointTrajectory.action
@@ -13,7 +13,7 @@ trajectory_msgs/MultiDOFJointTrajectory multi_dof_trajectory
 # violated, the goal aborts with error_code set to
 # PATH_TOLERANCE_VIOLATED.
 JointTolerance[] path_tolerance
-MultiDOFJointTolerance[] multi_dof_path_tolerance
+JointComponentTolerance[] component_path_tolerance
 
 # To report success, the joints must be within goal_tolerance of the
 # final trajectory value.  The goal must be achieved by time the
@@ -26,7 +26,7 @@ MultiDOFJointTolerance[] multi_dof_path_tolerance
 # time" + goal_time_tolerance, the goal aborts with error_code set to
 # GOAL_TOLERANCE_VIOLATED
 JointTolerance[] goal_tolerance
-MultiDOFJointTolerance[] multi_dof_goal_tolerance
+JointComponentTolerance[] component_goal_tolerance
 builtin_interfaces/Duration goal_time_tolerance
 
 ---

--- a/control_msgs/action/FollowJointTrajectory.action
+++ b/control_msgs/action/FollowJointTrajectory.action
@@ -12,6 +12,7 @@ trajectory_msgs/MultiDOFJointTrajectory multi_dof_trajectory
 # violated, the goal aborts with error_code set to
 # PATH_TOLERANCE_VIOLATED.
 JointTolerance[] path_tolerance
+MultiDOFJointTolerance[] multi_dof_path_tolerance
 
 # To report success, the joints must be within goal_tolerance of the
 # final trajectory value.  The goal must be achieved by time the
@@ -24,6 +25,7 @@ JointTolerance[] path_tolerance
 # time" + goal_time_tolerance, the goal aborts with error_code set to
 # GOAL_TOLERANCE_VIOLATED
 JointTolerance[] goal_tolerance
+MultiDOFJointTolerance[] multi_dof_goal_tolerance
 builtin_interfaces/Duration goal_time_tolerance
 
 ---
@@ -51,3 +53,7 @@ string[] joint_names
 trajectory_msgs/JointTrajectoryPoint desired
 trajectory_msgs/JointTrajectoryPoint actual
 trajectory_msgs/JointTrajectoryPoint error
+
+string[] multi_dof_joint_names
+trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_desired
+trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_actual

--- a/control_msgs/msg/JointComponentTolerance.msg
+++ b/control_msgs/msg/JointComponentTolerance.msg
@@ -1,4 +1,7 @@
-# The tolerances for a multi-dof joint
+# Version of JointTolerance.msg with added component field for joints with multiple degrees of freedom
+# The difference between two MultiDOFJointTrajectoryPoint cannot be represented as a single number,
+# hence we use the component field to represent how to calculate the difference in a way that can
+# be represented as a single number.
 
 # Since each joint has multiple degrees of freedom,
 # there can be multiple tolerances for each joint, each looking

--- a/control_msgs/msg/MultiDOFJointTolerance.msg
+++ b/control_msgs/msg/MultiDOFJointTolerance.msg
@@ -11,7 +11,7 @@
 # For these components, the units are meters, meters/sec and meters/sec^2.
 # Z_AXIS is only valid with a floating joint, not planar.
 
-# If the component is ANGULAR the tolerance is measured in
+# If the component is ROTATION the tolerance is measured in
 # radians, radians/sec and radians/sec^2, computed
 # between the difference in quaternions.
 

--- a/control_msgs/msg/MultiDOFJointTolerance.msg
+++ b/control_msgs/msg/MultiDOFJointTolerance.msg
@@ -1,0 +1,5 @@
+# MultiDOF version of JointTolerance
+string name
+geometry_msgs/Transform position
+geometry_msgs/Twist velocity
+geometry_msgs/Twist acceleration

--- a/control_msgs/msg/MultiDOFJointTolerance.msg
+++ b/control_msgs/msg/MultiDOFJointTolerance.msg
@@ -1,5 +1,28 @@
-# MultiDOF version of JointTolerance
-string name
-geometry_msgs/Transform position
-geometry_msgs/Twist velocity
-geometry_msgs/Twist acceleration
+# The tolerances for a multi-dof joint
+
+# Since each joint has multiple degrees of freedom,
+# there can be multiple tolerances for each joint, each looking
+# at different components.
+
+# If the component is X_AXIS, Y_AXIS, or Z_AXIS, then the tolerance
+# is only applied for the specific axis.
+# However, if the component is TRANSLATION, then the tolerance is for
+# the overall Euclidean distance.
+# For these components, the units are meters, meters/sec and meters/sec^2.
+# Z_AXIS is only valid with a floating joint, not planar.
+
+# If the component is ANGULAR the tolerance is measured in
+# radians, radians/sec and radians/sec^2, computed
+# between the difference in quaternions.
+
+uint16 X_AXIS=1
+uint16 Y_AXIS=2
+uint16 Z_AXIS=3
+uint16 TRANSLATION=4
+uint16 ROTATION=5
+
+string joint_name
+uint16 component
+float64 position
+float64 velocity
+float64 acceleration


### PR DESCRIPTION
Alternate approach for #16 

Adds `trajectory_msgs/MultiDOFJointTrajectory` to `FollowJointTrajectory.action` goal, as well as some related fields. 

Since this changes a core message, we should probably create a `galactic-devel` fork and merge there instead. However, adding the field shouldn't break too much since robots without a MultiDOF joint can just ignore the component. 

