### PR TITLE
Propose generic messages for commanding and getting states from controllers.

### DIFF
--- a/control_msgs/CHANGELOG.rst
+++ b/control_msgs/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package control_msgs
 
 4.2.0 (2023-03-22)
 ------------------
-* Add state message for mechanum controller #79 
+* Add state message for mechanum controller #79
 * Status message for steering controllers
 * Contributors: Denis Štogl, GiridharBukka, petkovich
 

--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -29,7 +29,11 @@ set(msg_files
   msg/JointJog.msg
   msg/JointTolerance.msg
   msg/JointTrajectoryControllerState.msg
+  msg/MultiDOFCommand.msg
+  msg/MultiDOFStateStamped.msg
   msg/PidState.msg
+  msg/SingleDOFState.msg
+  msg/SingleDOFStateStamped.msg
 )
 
 set(action_files

--- a/control_msgs/msg/JointTrajectoryControllerState.msg
+++ b/control_msgs/msg/JointTrajectoryControllerState.msg
@@ -1,5 +1,11 @@
 std_msgs/Header header
+
 string[] joint_names
 trajectory_msgs/JointTrajectoryPoint desired
 trajectory_msgs/JointTrajectoryPoint actual
 trajectory_msgs/JointTrajectoryPoint error  # Redundant, but useful
+
+string[] multi_dof_joint_names
+trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_desired
+trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_actual
+trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_error  # Redundant, but useful

--- a/control_msgs/msg/JointTrajectoryControllerState.msg
+++ b/control_msgs/msg/JointTrajectoryControllerState.msg
@@ -1,11 +1,5 @@
 std_msgs/Header header
-
 string[] joint_names
 trajectory_msgs/JointTrajectoryPoint desired
 trajectory_msgs/JointTrajectoryPoint actual
 trajectory_msgs/JointTrajectoryPoint error  # Redundant, but useful
-
-string[] multi_dof_joint_names
-trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_desired
-trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_actual
-trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_error  # Redundant, but useful

--- a/control_msgs/msg/MultiDOFCommand.msg
+++ b/control_msgs/msg/MultiDOFCommand.msg
@@ -11,4 +11,3 @@ float64[] values
 # First derivation of the values, e.g., velocity if values are positions.
 # This is useful for PID and similar controllers.
 float64[] values_dot
-

--- a/control_msgs/msg/MultiDOFCommand.msg
+++ b/control_msgs/msg/MultiDOFCommand.msg
@@ -1,0 +1,14 @@
+# The message defines command for multiple degrees of freedom (DoF) typically used by many controllers.
+# The message intentionally avoids 'joint' nomenclature because it can be generally use for command with
+# different semantic meanings, e.g., joints, Cartesian axes, or have abstract meaning like GPIO interface.
+
+# names of degrees of freedom
+string[] dof_names
+
+# values used by most of the controller
+float64[] values
+
+# First derivation of the values, e.g., velocity if values are positions.
+# This is useful for PID and similar controllers.
+float64[] values_dot
+

--- a/control_msgs/msg/MultiDOFStateStamped.msg
+++ b/control_msgs/msg/MultiDOFStateStamped.msg
@@ -1,0 +1,6 @@
+# This message presents current controller state of multiple degrees of freedom.
+
+# Header timestamp should be update time of controller state
+std_msgs/Header header
+
+SingleDOFState[] dof_states

--- a/control_msgs/msg/SingleDOFState.msg
+++ b/control_msgs/msg/SingleDOFState.msg
@@ -23,4 +23,3 @@ float64 time_step
 
 # Current output of the controller.
 float64 output
-

--- a/control_msgs/msg/SingleDOFState.msg
+++ b/control_msgs/msg/SingleDOFState.msg
@@ -4,13 +4,13 @@
 string name
 
 # The set point, that is, desired state.
-float64 set_point
+float64 reference
 
 # Current value of the process (ie: latest sensor measurement on the controlled value).
-float64 process_value
+float64 feedback
 
-# First time-derivative of the process value.
-float64 process_value_dot
+# First time-derivative of the process value. E.g., velocity.
+float64 feedback_dot
 
 # The error of the controlled value, essentially process_value - set_point (for a regular PID implementation).
 float64 error
@@ -22,5 +22,5 @@ float64 error_dot
 float64 time_step
 
 # Current output of the controller.
-float64 command
+float64 output
 

--- a/control_msgs/msg/SingleDOFState.msg
+++ b/control_msgs/msg/SingleDOFState.msg
@@ -15,6 +15,9 @@ float64 process_value_dot
 # The error of the controlled value, essentially process_value - set_point (for a regular PID implementation).
 float64 error
 
+# First time-derivative of the error of the controlled value.
+float64 error_dot
+
 # Time between two consecutive updates/execution of the control law.
 float64 time_step
 

--- a/control_msgs/msg/SingleDOFState.msg
+++ b/control_msgs/msg/SingleDOFState.msg
@@ -24,9 +24,3 @@ float64 time_step
 # Current output of the controller.
 float64 command
 
-# Current PID parameters of the controller.
-float64 p
-float64 i
-float64 d
-float64 i_clamp
-bool antiwindup

--- a/control_msgs/msg/SingleDOFState.msg
+++ b/control_msgs/msg/SingleDOFState.msg
@@ -1,9 +1,7 @@
-# This message presents current controller state of one joint.
+# This message presents current controller state of one degree of freedom.
 
-# It is deprecated as of Humble in favor of SingleDOFStateStamped.msg
-
-# Header timestamp should be update time of controller state
-std_msgs/Header header
+# DoF name, e.g., joint or Cartesian axis name
+string name
 
 # The set point, that is, desired state.
 float64 set_point

--- a/control_msgs/msg/SingleDOFStateStamped.msg
+++ b/control_msgs/msg/SingleDOFStateStamped.msg
@@ -1,0 +1,6 @@
+# This message presents current controller state of one degree of freedom.
+
+# Header timestamp should be update time of controller state
+std_msgs/Header header
+
+SingleDOFState dof_state

--- a/control_msgs/msg/SingleDOFStateStamped.msg
+++ b/control_msgs/msg/SingleDOFStateStamped.msg
@@ -1,6 +1,0 @@
-# This message presents current controller state of one degree of freedom.
-
-# Header timestamp should be update time of controller state
-std_msgs/Header header
-
-SingleDOFState dof_state


### PR DESCRIPTION
I propose here some new messages for sending commands to controllers.
This work  was motivated by the implementation of the PID controller in ros2_controllers repository.

The message `MultiDOFCommand` should replace `std_msgs/MultiArrayFloat64` currently used with the controllers.
The former is deprecated, and a new message enables to set joint (or in general DOF) names, which makes it more explicit than just a list of values.

Other messages specify a generic status messages, providing flexibility about degrees of freedom.

The PR can also be separated if some messages are not so suitable.
