### PR TITLE
🔧 Fixes and updated on pre-commit hooks and their action.

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,12 +6,6 @@ name: Format
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches:
-      - foxy-devel
-      - galactic-devel
-      - humble
-      - master
 
 jobs:
   pre-commit:
@@ -19,9 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-    - name: Install clang-format-10
-      run: sudo apt-get install clang-format-12 cppcheck
-    - uses: pre-commit/action@v2.0.3
+    - uses: actions/setup-python@v4.4.0
+      with:
+        python-version: '3.10'
+    - name: Install system hooks
+      run: sudo apt install -qq clang-format-14 cppcheck
+    - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --all-files --hook-stage manual

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -34,26 +34,26 @@ repos:
 
   # Python hooks
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.12.0
+    rev: v3.3.1
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.12.0
     hooks:
       - id: black
         args: ["--line-length=99"]
 
-  # PEP 257
-  - repo: https://github.com/FalconSocial/pre-commit-mirrors-pep257
-    rev: v0.3.3
+  # PyDocStyle
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.2.3
     hooks:
-    - id: pep257
+    - id: pydocstyle
       args: ["--ignore=D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404"]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.0
+    rev: 6.0.0
     hooks:
     - id: flake8
       args: ["--ignore=E501"]
@@ -93,14 +93,14 @@ repos:
 
   # Docs - RestructuredText hooks
   - repo: https://github.com/PyCQA/doc8
-    rev: 0.9.0a1
+    rev: v1.1.1
     hooks:
       - id: doc8
         args: ['--max-line-length=100', '--ignore=D001']
         exclude: CHANGELOG\.rst$
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: rst-backticks
         exclude: CHANGELOG\.rst$
@@ -110,7 +110,7 @@ repos:
   # Spellcheck in comments and docs
   # skipping of *.svg files is not working...
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.0.0
+    rev: v2.2.2
     hooks:
       - id: codespell
         args: ['--write-changes']


### PR DESCRIPTION
- Use pydocstyle instead of pep257 because it replaces it.
- Bump versions of hooks.
- Remove fixed python version from formatting action.
- Fix action warnings about Node.js 12 by updating them.
