### PR TITLE
Readd action msgs (revert #115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ To run it initially over the whole repo you can use:
   ```
   pre-commit run -a
   ```
+
+If you get error that something is missing on your computer, do the following for:
+
+  - `clang-format-10`
+     ```
+     sudo apt install clang-format-10
+     ```

--- a/README.md
+++ b/README.md
@@ -26,10 +26,3 @@ To run it initially over the whole repo you can use:
   ```
   pre-commit run -a
   ```
-
-If you get error that something is missing on your computer, do the following for:
-
-  - `clang-format-10`
-     ```
-     sudo apt install clang-format-10
-     ```

--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+find_package(action_msgs REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -60,6 +61,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
   DEPENDENCIES
+    action_msgs
     builtin_interfaces
     geometry_msgs
     sensor_msgs

--- a/control_msgs/package.xml
+++ b/control_msgs/package.xml
@@ -20,7 +20,7 @@
 
   <!-- action_msgs is needed up to humble -->
   <!-- https://github.com/ros2/rcl_interfaces/issues/75 -->
-  <!-- TODO(anyone) remove if master branch - compatibility on humble is not necessary any more -->
+  <!-- TODO(anyone) remove if master branch - compatibility on humble is not necessary anymore -->
   <depend>action_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>

--- a/control_msgs/package.xml
+++ b/control_msgs/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <depend>action_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/control_msgs/package.xml
+++ b/control_msgs/package.xml
@@ -18,6 +18,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <!-- action_msgs is needed up to humble -->
+  <!-- https://github.com/ros2/rcl_interfaces/issues/75 -->
+  <!-- TODO(anyone) remove if master branch - compatibility on humble is not necessary any more -->
   <depend>action_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>


### PR DESCRIPTION
Sorry for the noise. As @fmauch noticed within #115, the action_msg was needed up to humble. As we want to keep the master branch compatible with humble, we have to revert this.

Surprisingly, it seems to work on [ubuntu](https://github.com/ros-controls/ros2_control_ci/actions/runs/8320103128) but it fails on debian11

```
#23 93.16 --- stderr: control_msgs
#23 93.16 CMake Error at /opt/ros2_ws/install/rosidl_cmake/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:147 (message):
#23 93.16   Unable to generate action interface for
#23 93.16   'action/FollowJointTrajectory.action'.  In order to generate action
#23 93.16   interfaces you must add a depend tag for 'action_msgs' in your package.xml.
```

I added a comment in the package.xml why the dependency is there.