### PR TITLE
Add custom rosdoc2 config

### DIFF
--- a/.github/workflows/rosdoc2.yml
+++ b/.github/workflows/rosdoc2.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   check:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-rosdoc2.yml@rosdoc2
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-rosdoc2.yml@master

--- a/.github/workflows/rosdoc2.yml
+++ b/.github/workflows/rosdoc2.yml
@@ -1,0 +1,14 @@
+name: rosdoc2
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - control_msgs/doc/**
+      - control_msgs/rosdoc2.yaml
+      - control_msgs/package.xml
+
+
+jobs:
+  check:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-rosdoc2.yml@rosdoc2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,7 @@ repos:
         description: Check if copyright notice is available in all files.
         entry: ament_copyright
         language: system
+        exclude: doc/conf.py
 
   # Docs - RestructuredText hooks
   - repo: https://github.com/PyCQA/doc8

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 control_msgs
 ===========
 
+control_msgs contains base messages and actions useful for controlling robots. It provides representations for controller setpoints and joint and cartesian trajectories.
+
 See [control_msgs documentation](https://index.ros.org/p/control_msgs/) on index.ros.org
 
 

--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -52,11 +52,6 @@ set(srv_files
   srv/QueryTrajectoryState.srv
 )
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${action_files}
   ${msg_files}

--- a/control_msgs/doc/conf.py
+++ b/control_msgs/doc/conf.py
@@ -1,0 +1,5 @@
+# Configuration file for the Sphinx documentation builder.
+# settings will be overridden by rosdoc2, so we add here only custom settings
+
+copyright = "2024, ros2_control development team"
+html_logo = "https://control.ros.org/master/_static/logo_ros-controls.png"

--- a/control_msgs/doc/index.rst
+++ b/control_msgs/doc/index.rst
@@ -1,0 +1,23 @@
+Welcome to the documentation for control_msgs
+===============================================
+
+control_msgs contains base messages and actions useful for controlling robots. It provides representations for controller setpoints and joint and cartesian trajectories.
+
+For more information of the ros2_control framework see `control.ros.org <https://control.ros.org/>`__.
+
+API documentation
+------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   Action Definitions <generated/action_definitions>
+   Message Definitions <generated/message_definitions>
+   Service Definitions <generated/service_definitions>
+
+
+Indices and Search
+==================
+
+* :ref:`genindex`
+* :ref:`search`

--- a/control_msgs/package.xml
+++ b/control_msgs/package.xml
@@ -5,14 +5,14 @@
   <version>5.1.0</version>
   <description>
     control_msgs contains base messages and actions useful for
-    controlling robots.  It provides representations for controller
+    controlling robots. It provides representations for controller
     setpoints and joint and cartesian trajectories.
   </description>
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
 
   <license>BSD-3-Clause</license>
 
-  <url>http://ros.org/wiki/control_msgs</url>
+  <url type="website">https://control.ros.org</url>
   <author email="sglaser@willowgarage.com">Stuart Glaser</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
rosdoc2 will be used by the build farm to publish API docs on http://docs.ros.org/en/rolling/p/control_msgs/

- Add custom landing page for rosdoc2: logo, links to control.ros.org
- Copy over information from https://wiki.ros.org/control_msgs
- add rosdoc2 workflow, but only if the relevant files changed
- remove BUILD_TESTING, because ADD_LINTER_TESTS already does the job for the generated message files.

![image](https://github.com/ros-controls/control_msgs/assets/3367244/536d58ce-d616-491c-8f74-cb19bfd43e45)

