### PR TITLE
Add speed_scaling_factor msg and field in JointTrajectoryControllerState

### DIFF
--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -37,6 +37,7 @@ set(msg_files
   msg/SingleDOFState.msg
   msg/SingleDOFStateStamped.msg
   msg/SteeringControllerStatus.msg
+  msg/SpeedScalingFactor.msg
 )
 
 set(action_files

--- a/control_msgs/msg/JointTrajectoryControllerState.msg
+++ b/control_msgs/msg/JointTrajectoryControllerState.msg
@@ -22,3 +22,5 @@ trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_feedback
 trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_error
 # Current output of the controller.
 trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_output
+# The speed scaling factor the trajectory is currently being executed with
+float64 speed_scaling_factor

--- a/control_msgs/msg/SpeedScalingFactor.msg
+++ b/control_msgs/msg/SpeedScalingFactor.msg
@@ -1,0 +1,5 @@
+# This message contains a scaling factor to scale trajectory execution. A factor of 1.0 means
+# execution at normal speed, a factor of 0.0 means a full pause.
+# Negative values are not allowed (Which should be checked by any instance consuming this message).
+
+float64 factor


### PR DESCRIPTION
This goes in line with https://github.com/ros-controls/ros2_controllers/pull/1191

Note: For backporting it is planned to not add the field in the JTCState message.