### PR TITLE
[pid] Add documentation to fields

### DIFF
--- a/control_msgs/msg/PidState.msg
+++ b/control_msgs/msg/PidState.msg
@@ -1,13 +1,28 @@
 std_msgs/Header header
 builtin_interfaces/Duration timestep
+
+# error = target - state
 float64 error
+# derivative of error
 float64 error_dot
+
+# equals error
 float64 p_error
+# weighted integral of error
 float64 i_error
+# equals derivative of error
 float64 d_error
+
+# proportional gain
 float64 p_term
+# integral gain
 float64 i_term
+# derivative gain
 float64 d_term
+# upper integral clamp.
 float64 i_max
+# lower integral clamp.
 float64 i_min
+
+# output of the PID controller
 float64 output


### PR DESCRIPTION
1. p_error and d_error are duplicates, see [here](https://github.com/ros-controls/control_toolbox/blob/55756bf41b395cb45d44b210a1b27cf503797b8b/src/pid.cpp#L199-L200)
2. p_term, i_term, d_term is actually misleading, because they are the [gains](https://github.com/ros-controls/control_toolbox/blob/55756bf41b395cb45d44b210a1b27cf503797b8b/src/pid_ros.cpp#L289-L291).



can we change it? (will break packages using it) 
or shall we deprecate it and add new ones?