### PR TITLE
Adds members to pid state message

### DIFF
--- a/control_msgs/msg/PidState.msg
+++ b/control_msgs/msg/PidState.msg
@@ -15,10 +15,6 @@ float64 p_gain
 float64 i_gain
 # derivative gain
 float64 d_gain
-# upper integral clamp.
-float64 i_max
-# lower integral clamp.
-float64 i_min
 
 # output of the PID controller
 float64 output


### PR DESCRIPTION
Remove members from the pid state message to make it cleaner, without affecting users.

These changes support modifications made to the PID controller in the control_toolbox package. For more details, see https://github.com/ros-controls/control_toolbox/pull/298.

If this PR is approved, it should be merged together with the main PR in the control_toolbox package referenced above.