### PR TITLE
Update CMake

### DIFF
--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 
 project(control_msgs)
 

--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -2,14 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 
 project(control_msgs)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 find_package(action_msgs REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)


### PR DESCRIPTION
- C++ version and compiler flags are not necessary: https://github.com/ros2/example_interfaces/issues/22#issuecomment-2945481570
- CMake < 3.11 is deprecated on some platforms https://github.com/ros-controls/ros2_control_cmake/pull/8#pullrequestreview-2904365381

Closes #203