### PR TITLE
Add message to control a robot via linear velocity and steering position

### DIFF
--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -30,6 +30,7 @@ set(msg_files
   msg/SingleDOFState.msg
   msg/SingleDOFStateStamped.msg
   msg/SteeringControllerStatus.msg
+  msg/SteeringControllerCommand.msg
   msg/SpeedScalingFactor.msg
 )
 

--- a/control_msgs/action/FollowJointTrajectory.action
+++ b/control_msgs/action/FollowJointTrajectory.action
@@ -54,8 +54,12 @@ string[] joint_names
 trajectory_msgs/JointTrajectoryPoint desired
 trajectory_msgs/JointTrajectoryPoint actual
 trajectory_msgs/JointTrajectoryPoint error
+# the currently used point from trajectory.points array
+int32 index
 
 string[] multi_dof_joint_names
 trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_desired
 trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_actual
 trajectory_msgs/MultiDOFJointTrajectoryPoint multi_dof_error
+# the currently used point from multi_dof_trajectory.points array
+int32 multi_dof_index

--- a/control_msgs/msg/SteeringControllerCommand.msg
+++ b/control_msgs/msg/SteeringControllerCommand.msg
@@ -1,3 +1,3 @@
 std_msgs/Header header
-float64 steering_angle  # desired positions of the steering joints
-float64 linear_velocity # desired linear velocity of the robot
+float64 steering_angle  # in rad
+float64 linear_velocity # in m/s

--- a/control_msgs/msg/SteeringControllerCommand.msg
+++ b/control_msgs/msg/SteeringControllerCommand.msg
@@ -1,3 +1,3 @@
 std_msgs/Header header
 float64 steering_angle  # desired positions of the steering joints
-float64 linear_velocity # desired linear velocity of the robot 
+float64 linear_velocity # desired linear velocity of the robot

--- a/control_msgs/msg/SteeringControllerCommand.msg
+++ b/control_msgs/msg/SteeringControllerCommand.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+float64 steering_angle  # desired positions of the steering joints
+float64 linear_velocity # desired linear velocity of the robot 


### PR DESCRIPTION
This PR adds a new message that allows specifying a linear velocity and a steering position as used in https://github.com/ros-controls/ros2_controllers/pull/1563. I am not entirely happy with the descriptive text here:
```
float64 linear_velocity # desired linear velocity of the robot 
```
Any ideas how to describe it better? A robot does not necessarily have a steering wheel, but often some kind of common element that influences the position of the wheels. 