### PR TITLE
Add vda5050 safety state msg

### DIFF
--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -45,6 +45,7 @@ set(msg_files
   msg/SteeringControllerStatus.msg
   msg/SteeringControllerCommand.msg
   msg/SpeedScalingFactor.msg
+  msg/VDA5050SafetyState.msg
   msg/VDA5050State.msg
   msg/WrenchFramed.msg
 )

--- a/control_msgs/msg/VDA5050SafetyState.msg
+++ b/control_msgs/msg/VDA5050SafetyState.msg
@@ -1,0 +1,12 @@
+string e_stop           # Enum {autoAck, manual, remote, none} Acknowledge-Type of eStop:
+                        # autoAck: autoacknowledgeable e-stop is activated e.g. by bumper or protective field
+                        # manual: e-stop has to be acknowledged manually at the vehicle
+                        # remote: facility estop has to be acknowledged remotely
+                        # none: no e-stop activated
+bool field_violation    # Protective field violation. True: field is violated False: field is not violated
+
+# Enums for eStop
+string AUTO_ACK="autoAck"
+string MANUAL="manual"
+string REMOTE="remote"
+string NONE="none"


### PR DESCRIPTION
This PR introduces a new message definition: `VDA5050SafetyState`.

`VDA5050SafetyState` provides a standardized message for reporting the safety state of a robot or AGV in accordance with the **VDA5050 schema**. The fields and enumerations in this message are directly derived from the official VDA5050 specification to ensure compatibility with VDA5050-compliant fleet management systems and controllers.

While this message already exists in the [ipa320/vda5050_msgs](https://github.com/ipa320/vda5050_msgs/blob/ros2/vda5050_msgs/msg/SafetyState.msg) package, it is being added to control_msgs to:

- Enable direct integration with the upcoming `vda5050_safety_state_broadcaster` in `ros2_controllers`, and

- Ensure that the message is maintained and versioned alongside other core control interfaces.

---

Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. Don’t be afraid to request reviews from maintainers.
5. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
