### PR TITLE
feat: add JointCommand.msg for semantic forward control

### DIFF
--- a/control_msgs/CMakeLists.txt
+++ b/control_msgs/CMakeLists.txt
@@ -30,6 +30,7 @@ set(msg_files
   msg/Keys.msg
   msg/Float64Values.msg
   msg/JointComponentTolerance.msg
+  msg/JointCommand.msg
   msg/JointControllerState.msg
   msg/JointJog.msg
   msg/JointTolerance.msg

--- a/control_msgs/msg/JointCommand.msg
+++ b/control_msgs/msg/JointCommand.msg
@@ -1,0 +1,12 @@
+# This message contains the command for a specific interface across multiple joints.
+
+std_msgs/Header header
+
+# List of joint names to command.
+string[] joint_names
+
+# The specific interface type to command (e.g., "position", "velocity", "effort").
+string interface_name
+
+# The commanded values. The length of this array must exactly match the length of joint_names.
+float64[] values


### PR DESCRIPTION
### Summary
This PR introduces `JointCommand.msg` to `control_msgs`. This provides a timestamped, semantically clear alternative to the deprecated `std_msgs/Float64MultiArray` currently utilized in `forward_command_controller`.

### Justification & Context
1. **Safety Timeouts:** The current use of `Float64MultiArray` lacks a header stamp, which prevents the implementation of watchdog mechanisms. This new message includes a `std_msgs/Header` to unblock safety timeouts (referencing `ros-controls/ros2_controllers#95`).
2. **Unified Controller Architecture:** Following the deprecation of specialized forward controllers (ref: `ros-controls/ros2_controllers#1913`), the generic `forward_command_controller` requires a way to identify command types dynamically. The `interface_name` field explicitly defines whether a command is for position, velocity, effort, etc., without requiring a "message explosion" of unique types.
3. **Resolves Deprecation Debt:** This unblocks the cleanup of deprecated `std_msgs` and `example_interfaces` usage tracked in `ros-controls/ros2_controllers#157` and `gz_ros2_control#292`.

### Contribution Checklist
- [x] **Limited Scope:** Only adds the new message definition and updates build files.
- [x] **Descriptive Title:** Provided.
- [x] **Pipeline:** Verified local build on ROS 2 Rolling and passed all `pre-commit` linters (ament_lint_cmake, ament_copyright, etc.).
- [x] **Testing:** Verified message generation and member accessibility via `ros2 interface show`.

### Message Structure
- `std_msgs/Header header`: Timestamp for watchdog/timeout logic.
- `string[] joint_names`: Explicit targeting of joints.
- `string interface_name`: Defines the interface (e.g., "position", "velocity").
- `float64[] values`: The commanded values.

Once merged, I will submit the corresponding PR in `ros2_controllers` to integrate this message and implement the safety watchdog logic.